### PR TITLE
fix: disable mime type sniffing

### DIFF
--- a/_headers
+++ b/_headers
@@ -4,3 +4,4 @@
     Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
     X-Frame-Options: DENY
     X-XSS-Protection: 1; mode=block
+    X-Content-Type-Options: nosniff


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options